### PR TITLE
Fix/optimize iovec gathering

### DIFF
--- a/constants/main.go
+++ b/constants/main.go
@@ -14,36 +14,47 @@ const (
 	IpV4HeaderStart          = 14
 	MinFrameSize             = 60
 	PcapCaptureTimeout       = time.Millisecond * 30
-	//SendMmsgSyscallIndex     = -1
-	TcpV4PacketPayloadSize = 54
-	UdpV4PacketPayloadSize = 42
-	UpHostsChanSize        = 1024
+	TcpV4PacketPayloadSize   = 54
+	UdpV4PacketPayloadSize   = 42
+	UpHostsChanSize          = 1024
 )
 
-// ArpPacketSkeleton is a minimal ARP request frame.
-var ArpPacketSkeleton = [MinFrameSize]byte{
+const ArpAndEthernetHeadersSize = 22
+
+// ArpAndEthernetHeaders This array covers bytes [0..22) of the original skeleton (Ethernet + first part of ARP header).
+var ArpAndEthernetHeaders = [ArpAndEthernetHeadersSize]byte{
 	// Ethernet header (14 bytes)
-	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // [0:6]   Destination MAC: FF:FF:FF:FF:FF:FF (broadcast)
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [6:12]  Source MAC - should be specified
-	0x08, 0x06, // [12:14] EtherType: 0x0806 (ARP)
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // [0:6]   Destination MAC (was [0:6])
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [6:12]  Source MAC (was [6:12])
+	0x08, 0x06, // [12:14] EtherType: 0x0806 (ARP) (was [12:14])
 
-	// ARP header (28 bytes total)
-	0x00, 0x01, // [14:16] Hardware Type: 1 (Ethernet)
-	0x08, 0x00, // [16:18] Protocol Type: 0x0800 (IPv4)
-	0x06,       // [18]    Hardware Address Size: 6 (MAC length)
-	0x04,       // [19]    Protocol Address Size: 4 (IPv4 length)
-	0x00, 0x01, // [20:22] Operation: 1 (ARP Request)
+	// ARP header (part of the 28 bytes)
+	0x00, 0x01, // [14:16] Hardware Type: 1 (Ethernet) (was [14:16])
+	0x08, 0x00, // [16:18] Protocol Type: 0x0800 (IPv4) (was [16:18])
+	0x06,       // [18]    Hardware Address Size: 6 (was [18])
+	0x04,       // [19]    Protocol Address Size: 4 (was [19])
+	0x00, 0x01, // [20:22] Operation: 1 (ARP Request) (was [20:22])
+}
 
+const ArpPacketPayloadBodySize = 20
+
+// ArpPacketPayload This array covers bytes [22..42) of the original skeleton (the ARP body).
+var ArpPacketPayload = [ArpPacketPayloadBodySize]byte{
 	// ARP body
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [22:28] Sender HW address - should be specified
-	0x00, 0x00, 0x00, 0x00, // [28:32] Sender IP - should be specified
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [32:38] Target HW address
-	0x00, 0x00, 0x00, 0x00, // [38:42] Target IP - should be specified
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [0:6]   Sender HW address (was [22:28])
+	0x00, 0x00, 0x00, 0x00, // [6:10]  Sender IP (was [28:32])
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [10:16] Target HW address (was [32:38])
+	0x00, 0x00, 0x00, 0x00, // [16:20] Target IP (was [38:42])
+}
 
+const ArpPacketPaddingSize = 18
+
+// ArpPacketPadding This array covers bytes [42..60) of the original skeleton (the padding).
+var ArpPacketPadding = [ArpPacketPaddingSize]byte{
 	// Padding (to reach the minimum Ethernet frame length of 60 bytes)
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [0:18] (was [42:60])
 }
 
 // PingPacketSkeleton is a minimal ICMP Echo Request frame.

--- a/constants/main.go
+++ b/constants/main.go
@@ -10,9 +10,6 @@ const (
 	GatewayMacRequestTimeout = time.Second * 1
 	IOVecPacketsChunkSize    = 64
 	IcmpV4PacketPayloadSize  = 42
-	IpHeaderLength           = 20
-	IpV4HeaderStart          = 14
-	MinFrameSize             = 60
 	PcapCaptureTimeout       = time.Millisecond * 30
 	TcpV4PacketPayloadSize   = 54
 	UdpV4PacketPayloadSize   = 42

--- a/constants/main.go
+++ b/constants/main.go
@@ -57,31 +57,6 @@ var ArpPacketPaddingPart = [ArpPacketPaddingSize]byte{
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [0:18] (was [42:60])
 }
 
-//// PingPacketSkeleton is a minimal ICMP Echo Request frame.
-//var PingPacketSkeleton = [MinFrameSize]byte{
-//	// Ethernet header (14 bytes)
-//	0, 0, 0, 0, 0, 0, // [0:6]   Destination MAC - should be specified
-//	0, 0, 0, 0, 0, 0, // [6:12]  Source MAC - should be specified
-//	8, 0, // [12:14] EtherType: 0x0800 (IPv4)
-//
-//	// IPv4 header (20 bytes for a minimal header)
-//	69, 0, 0, 32, // [14:18] IPv4 Version, IHL, Type of Service, Total Length
-//	0, 0, // [18:20] Identification
-//	64, 0, // [20:22] Flags, Fragment Offset
-//	64, 1, 0, 0, // [22:26] TTL, Protocol (ICMP), Header Checksum
-//	0, 0, 0, 0, // [26:30] Source IP - should be specified
-//	255, 0, 0, 0, // [30:34] Destination - should be specified
-//
-//	// ICMP header and payload
-//	8, 0, // [34:36] ICMP Type (8 for Echo Request), Code (0)
-//	71, 58, // [36:38] Checksum of ICMP packet
-//	18, 52, 0, 1, // [38:42] Identifier and Sequence (part of payload)
-//	80, 73, 78, 71, // [42:46] Payload ("PING")
-//
-//	// Padding to reach minimum Ethernet frame size
-//	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//}
-
 const ICMPPacketEthernetPartSize = 14
 
 // ICMPPacketEthernetPart is the Ethernet header (14 bytes).

--- a/constants/main.go
+++ b/constants/main.go
@@ -21,8 +21,8 @@ const (
 
 const ArpAndEthernetHeadersSize = 22
 
-// ArpAndEthernetHeaders This array covers bytes [0..22) of the original skeleton (Ethernet + first part of ARP header).
-var ArpAndEthernetHeaders = [ArpAndEthernetHeadersSize]byte{
+// ArpAndEthernetHeadersPart This array covers bytes [0..22) of the original skeleton (Ethernet + first part of ARP header).
+var ArpAndEthernetHeadersPart = [ArpAndEthernetHeadersSize]byte{
 	// Ethernet header (14 bytes)
 	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // [0:6]   Destination MAC (was [0:6])
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [6:12]  Source MAC (was [6:12])
@@ -38,8 +38,8 @@ var ArpAndEthernetHeaders = [ArpAndEthernetHeadersSize]byte{
 
 const ArpPacketPayloadBodySize = 20
 
-// ArpPacketPayload This array covers bytes [22..42) of the original skeleton (the ARP body).
-var ArpPacketPayload = [ArpPacketPayloadBodySize]byte{
+// ArpPacketPayloadPart This array covers bytes [22..42) of the original skeleton (the ARP body).
+var ArpPacketPayloadPart = [ArpPacketPayloadBodySize]byte{
 	// ARP body
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [0:6]   Sender HW address (was [22:28])
 	0x00, 0x00, 0x00, 0x00, // [6:10]  Sender IP (was [28:32])
@@ -49,36 +49,82 @@ var ArpPacketPayload = [ArpPacketPayloadBodySize]byte{
 
 const ArpPacketPaddingSize = 18
 
-// ArpPacketPadding This array covers bytes [42..60) of the original skeleton (the padding).
-var ArpPacketPadding = [ArpPacketPaddingSize]byte{
+// ArpPacketPaddingPart This array covers bytes [42..60) of the original skeleton (the padding).
+var ArpPacketPaddingPart = [ArpPacketPaddingSize]byte{
 	// Padding (to reach the minimum Ethernet frame length of 60 bytes)
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // [0:18] (was [42:60])
 }
 
-// PingPacketSkeleton is a minimal ICMP Echo Request frame.
-var PingPacketSkeleton = [MinFrameSize]byte{
-	// Ethernet header (14 bytes)
-	0, 0, 0, 0, 0, 0, // [0:6]   Destination MAC - should be specified
-	0, 0, 0, 0, 0, 0, // [6:12]  Source MAC - should be specified
-	8, 0, // [12:14] EtherType: 0x0800 (IPv4)
+//// PingPacketSkeleton is a minimal ICMP Echo Request frame.
+//var PingPacketSkeleton = [MinFrameSize]byte{
+//	// Ethernet header (14 bytes)
+//	0, 0, 0, 0, 0, 0, // [0:6]   Destination MAC - should be specified
+//	0, 0, 0, 0, 0, 0, // [6:12]  Source MAC - should be specified
+//	8, 0, // [12:14] EtherType: 0x0800 (IPv4)
+//
+//	// IPv4 header (20 bytes for a minimal header)
+//	69, 0, 0, 32, // [14:18] IPv4 Version, IHL, Type of Service, Total Length
+//	0, 0, // [18:20] Identification
+//	64, 0, // [20:22] Flags, Fragment Offset
+//	64, 1, 0, 0, // [22:26] TTL, Protocol (ICMP), Header Checksum
+//	0, 0, 0, 0, // [26:30] Source IP - should be specified
+//	255, 0, 0, 0, // [30:34] Destination - should be specified
+//
+//	// ICMP header and payload
+//	8, 0, // [34:36] ICMP Type (8 for Echo Request), Code (0)
+//	71, 58, // [36:38] Checksum of ICMP packet
+//	18, 52, 0, 1, // [38:42] Identifier and Sequence (part of payload)
+//	80, 73, 78, 71, // [42:46] Payload ("PING")
+//
+//	// Padding to reach minimum Ethernet frame size
+//	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//}
 
-	// IPv4 header (20 bytes for a minimal header)
-	69, 0, 0, 32, // [14:18] IPv4 Version, IHL, Type of Service, Total Length
-	0, 0, // [18:20] Identification
-	64, 0, // [20:22] Flags, Fragment Offset
-	64, 1, 0, 0, // [22:26] TTL, Protocol (ICMP), Header Checksum
-	0, 0, 0, 0, // [26:30] Source IP - should be specified
-	255, 0, 0, 0, // [30:34] Destination - should be specified
+const ICMPPacketEthernetPartSize = 14
 
-	// ICMP header and payload
-	8, 0, // [34:36] ICMP Type (8 for Echo Request), Code (0)
-	71, 58, // [36:38] Checksum of ICMP packet
-	18, 52, 0, 1, // [38:42] Identifier and Sequence (part of payload)
-	80, 73, 78, 71, // [42:46] Payload ("PING")
+// ICMPPacketEthernetPart is the Ethernet header (14 bytes).
+var ICMPPacketEthernetPart = [ICMPPacketEthernetPartSize]byte{
+	// [0:6]   Destination MAC - should be specified
+	0, 0, 0, 0, 0, 0,
+	// [6:12]  Source MAC - should be specified
+	0, 0, 0, 0, 0, 0,
+	// [12:14] EtherType: 0x0800 (IPv4)
+	8, 0,
+}
 
-	// Padding to reach minimum Ethernet frame size
+const ICMPPacketIPPartSize = 20
+
+// ICMPPacketIPPart is the IPv4 header (20 bytes for a minimal header).
+var ICMPPacketIPPart = [ICMPPacketIPPartSize]byte{
+	// [0:4]   IPv4 Version, IHL, Type of Service, Total Length
+	69, 0, 0, 32,
+	// [4:6]   Identification
+	0, 0,
+	// [6:8]   Flags, Fragment Offset
+	64, 0,
+	// [8:12]  TTL, Protocol (ICMP), Header Checksum
+	64, 1, 0, 0,
+	// [12:16] Source IP - should be specified
+	0, 0, 0, 0,
+	// [16:20] Destination IP - should be specified
+	255, 0, 0, 0,
+}
+
+const ICMPPacketICMPPartAndPaddingSize = 26
+
+// ICMPPacketICMPPartAndPadding is the ICMP header plus payload and padding (26 bytes).
+var ICMPPacketICMPPartAndPadding = [ICMPPacketICMPPartAndPaddingSize]byte{
+	// [0:2]   ICMP Type (8 for Echo Request), Code (0)
+	8, 0,
+	// [2:4]   ICMP Checksum
+	71, 58,
+	// [4:8]   Identifier and Sequence
+	18, 52, 0, 1,
+	// [8:12]  Payload ("PING")
+	80, 73, 78, 71,
+	// [12:26] Padding to reach minimum Ethernet frame size
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 }
 

--- a/constants/sendmmsg_linux_arm64.go
+++ b/constants/sendmmsg_linux_arm64.go
@@ -2,5 +2,5 @@
 
 package constants
 
-// https://github.com/torvalds/linux/blob/95ec54a420b8f445e04a7ca0ea8deb72c51fe1d3/scripts/syscall.tbl#L319
+// SendMmsgSyscallIndex https://github.com/torvalds/linux/blob/95ec54a420b8f445e04a7ca0ea8deb72c51fe1d3/scripts/syscall.tbl#L319
 const SendMmsgSyscallIndex = 269

--- a/constants/sendmmsg_linux_x86_32.go
+++ b/constants/sendmmsg_linux_x86_32.go
@@ -2,5 +2,5 @@
 
 package constants
 
-// https://github.com/torvalds/linux/blob/ffd294d346d185b70e28b1a28abe367bbfe53c04/arch/x86/entry/syscalls/syscall_64.tbl#L426
+// SendMmsgSyscallIndex https://github.com/torvalds/linux/blob/ffd294d346d185b70e28b1a28abe367bbfe53c04/arch/x86/entry/syscalls/syscall_64.tbl#L426
 const SendMmsgSyscallIndex = 538

--- a/constants/sendmmsg_linux_x86_64.go
+++ b/constants/sendmmsg_linux_x86_64.go
@@ -2,5 +2,5 @@
 
 package constants
 
-// https://github.com/torvalds/linux/blob/ffd294d346d185b70e28b1a28abe367bbfe53c04/arch/x86/entry/syscalls/syscall_64.tbl#L319
+// SendMmsgSyscallIndex https://github.com/torvalds/linux/blob/ffd294d346d185b70e28b1a28abe367bbfe53c04/arch/x86/entry/syscalls/syscall_64.tbl#L319
 const SendMmsgSyscallIndex = 307

--- a/scanner/main.go
+++ b/scanner/main.go
@@ -78,20 +78,28 @@ func createScannerContext(r rule.Rule) (*scannerContext, error) {
 	return &c, nil
 }
 
-func prepareIcmpEchoPacketTemplate(sourceMAC, destinationMAC net.HardwareAddr, sourceIP net.IP) [constants.MinFrameSize]byte {
-	var icmpEchoPacketTemplate [constants.MinFrameSize]byte
-	icmpEchoPacketTemplate = constants.PingPacketSkeleton
+func prepareIcmpPacketEthernetPart(sourceMAC, destinationMAC net.HardwareAddr) [constants.ICMPPacketEthernetPartSize]byte {
+	var ICMPPacketEthernetPartTemplate [constants.ICMPPacketEthernetPartSize]byte
+	ICMPPacketEthernetPartTemplate = constants.ICMPPacketEthernetPart
 
-	copy(icmpEchoPacketTemplate[0:6], destinationMAC)
-	copy(icmpEchoPacketTemplate[6:12], sourceMAC)
-	copy(icmpEchoPacketTemplate[26:30], sourceIP)
+	copy(ICMPPacketEthernetPartTemplate[0:6], destinationMAC)
+	copy(ICMPPacketEthernetPartTemplate[6:12], sourceMAC)
 
-	return icmpEchoPacketTemplate
+	return ICMPPacketEthernetPartTemplate
+}
+
+func prepareIcmpPacketIpPartTemplate(sourceIP net.IP) [constants.ICMPPacketIPPartSize]byte {
+	var ICMPPacketIPPartTemplate [constants.ICMPPacketIPPartSize]byte
+	ICMPPacketIPPartTemplate = constants.ICMPPacketIPPart
+
+	copy(ICMPPacketIPPartTemplate[12:], sourceIP.To4())
+
+	return ICMPPacketIPPartTemplate
 }
 
 func prepareArpAndEthernetHeadersTemplate(localMAC net.HardwareAddr) [constants.ArpAndEthernetHeadersSize]byte {
 	var arpPacketEthernetArpHeadersTemplate [constants.ArpAndEthernetHeadersSize]byte
-	arpPacketEthernetArpHeadersTemplate = constants.ArpAndEthernetHeaders
+	arpPacketEthernetArpHeadersTemplate = constants.ArpAndEthernetHeadersPart
 
 	copy(arpPacketEthernetArpHeadersTemplate[6:], localMAC)
 
@@ -100,7 +108,7 @@ func prepareArpAndEthernetHeadersTemplate(localMAC net.HardwareAddr) [constants.
 
 func prepareArpPacketBodyTemplate(localMAC net.HardwareAddr, localIP net.IP) [20]byte {
 	var ArpPacketPayloadTemplate [20]byte
-	ArpPacketPayloadTemplate = constants.ArpPacketPayload
+	ArpPacketPayloadTemplate = constants.ArpPacketPayloadPart
 
 	copy(ArpPacketPayloadTemplate[0:], localMAC)
 	copy(ArpPacketPayloadTemplate[6:], localIP)

--- a/scanner/main.go
+++ b/scanner/main.go
@@ -89,17 +89,23 @@ func prepareIcmpEchoPacketTemplate(sourceMAC, destinationMAC net.HardwareAddr, s
 	return icmpEchoPacketTemplate
 }
 
-// prepareArpPacketTemplate creates a minimal ARP packet,
-// taking into account the specified local MAC and IP addresses.
-func prepareArpPacketTemplate(localMAC net.HardwareAddr, localIP net.IP) [constants.MinFrameSize]byte {
-	var arpPacketTemplate [constants.MinFrameSize]byte
-	arpPacketTemplate = constants.ArpPacketSkeleton
+func prepareArpAndEthernetHeadersTemplate(localMAC net.HardwareAddr) [constants.ArpAndEthernetHeadersSize]byte {
+	var arpPacketEthernetArpHeadersTemplate [constants.ArpAndEthernetHeadersSize]byte
+	arpPacketEthernetArpHeadersTemplate = constants.ArpAndEthernetHeaders
 
-	copy(arpPacketTemplate[6:], localMAC)
-	copy(arpPacketTemplate[22:], localMAC)
-	copy(arpPacketTemplate[28:], localIP)
+	copy(arpPacketEthernetArpHeadersTemplate[6:], localMAC)
 
-	return arpPacketTemplate
+	return arpPacketEthernetArpHeadersTemplate
+}
+
+func prepareArpPacketBodyTemplate(localMAC net.HardwareAddr, localIP net.IP) [20]byte {
+	var ArpPacketPayloadTemplate [20]byte
+	ArpPacketPayloadTemplate = constants.ArpPacketPayload
+
+	copy(ArpPacketPayloadTemplate[0:], localMAC)
+	copy(ArpPacketPayloadTemplate[6:], localIP)
+
+	return ArpPacketPayloadTemplate
 }
 
 // interceptArpPackets listens for ARP packets on the given interface within the specified subnet.

--- a/scanner/vertical.go
+++ b/scanner/vertical.go
@@ -73,6 +73,7 @@ func arpScan(c *scannerContext, r *router.IpRangeRouteContext, arpWg *sync.WaitG
 			uintptr(unsafe.Pointer(&messageHeaders[0])),
 			uintptr(len(messageHeaders)),
 		)
+
 		if errno != 0 {
 			c.errorChan <- errno
 		}
@@ -126,20 +127,24 @@ func pingScan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net.H
 				Base: &IcmpPacketEthernetPart[0],
 				Len:  constants.ICMPPacketEthernetPartSize,
 			}
+
 			ioVectors[i][1] = syscall.Iovec{
 				Base: &rawICMPPacketsIpPart[i][0],
 				Len:  constants.ICMPPacketIPPartSize,
 			}
+
 			ioVectors[i][2] = syscall.Iovec{
 				Base: &constants.ICMPPacketICMPPartAndPadding[0],
 				Len:  constants.ICMPPacketICMPPartAndPaddingSize,
 			}
+
 			messageHeaders[i].Msg = syscall.Msghdr{
 				Name:    r.SocketParameters.SocketAddressName,
 				Namelen: r.SocketParameters.SocketAddressNameLen,
 				Iov:     &ioVectors[i][0],
 				Iovlen:  3,
 			}
+
 		}
 		if err := Limiter.Wait(context.Background()); err != nil {
 			c.errorChan <- err
@@ -151,6 +156,7 @@ func pingScan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net.H
 			uintptr(unsafe.Pointer(&messageHeaders[0])),
 			uintptr(len(messageHeaders)),
 		)
+		
 		if errno != 0 {
 			c.errorChan <- errno
 		}

--- a/scanner/vertical.go
+++ b/scanner/vertical.go
@@ -17,39 +17,50 @@ import (
 
 // arpScan sends ARP requests for each IP address in the subnet and waits for replies.
 func arpScan(c *scannerContext, r *router.IpRangeRouteContext, arpWg *sync.WaitGroup) {
-	//defer fmt.Println("DEBUG: scanOverGateway is done")
+
 	defer close(r.ReadyToInterceptChan)
 	defer arpWg.Done()
 
-	// Prepare slices of structures for the sendmmsg syscall
 	var messageHeaders [constants.IOVecPacketsChunkSize]Mmsghdr
-	var rawArpPackets [constants.IOVecPacketsChunkSize][constants.MinFrameSize]byte
-	var ioVectors [constants.IOVecPacketsChunkSize]syscall.Iovec
+	var ethernetAndArpHeadersTemplate [constants.ArpAndEthernetHeadersSize]byte
+	var arpPacketBodyTemplate [constants.ArpPacketPayloadBodySize]byte
+	var rawArpPacketBodies [constants.IOVecPacketsChunkSize][20]byte
+	var ioVectors [constants.IOVecPacketsChunkSize][3]syscall.Iovec
 
 	arpWg.Add(1)
 	go interceptArpPackets(c, r, arpWg)
 
 	<-r.ReadyToInterceptChan
 
-	arpPacketTemplate := prepareArpPacketTemplate(r.SocketParameters.SourceInterface.HardwareAddr, r.Route.Src)
-	packetLength := uint64(constants.MinFrameSize)
+	ethernetAndArpHeadersTemplate = prepareArpAndEthernetHeadersTemplate(r.SocketParameters.SourceInterface.HardwareAddr)
+	arpPacketBodyTemplate = prepareArpPacketBodyTemplate(r.SocketParameters.SourceInterface.HardwareAddr, r.Route.Src)
 
-	// Generate ARP packets for each IP chunk in the subnet
-	// TODO
 	for _, ipChunk := range utils.IterateIpRangeChunksBytes(r.Start, r.End) {
 		for i := range ipChunk {
-			rawArpPackets[i] = arpPacketTemplate
-			copy(rawArpPackets[i][38:], ipChunk[i][:])
 
-			ioVectors[i] = syscall.Iovec{
-				Base: &rawArpPackets[i][0],
-				Len:  packetLength,
+			rawArpPacketBodies[i] = arpPacketBodyTemplate
+			copy(rawArpPacketBodies[i][16:], ipChunk[i][:])
+
+			ioVectors[i][0] = syscall.Iovec{
+				Base: &ethernetAndArpHeadersTemplate[0],
+				Len:  22,
 			}
+
+			ioVectors[i][1] = syscall.Iovec{
+				Base: &rawArpPacketBodies[i][0],
+				Len:  20,
+			}
+
+			ioVectors[i][2] = syscall.Iovec{
+				Base: &constants.ArpPacketPadding[0],
+				Len:  18,
+			}
+
 			messageHeaders[i].Msg = syscall.Msghdr{
 				Name:    r.SocketParameters.SocketAddressName,
 				Namelen: r.SocketParameters.SocketAddressNameLen,
-				Iov:     &ioVectors[i],
-				Iovlen:  1,
+				Iov:     &ioVectors[i][0],
+				Iovlen:  3,
 			}
 		}
 		if err := Limiter.Wait(context.Background()); err != nil {

--- a/scanner/vertical.go
+++ b/scanner/vertical.go
@@ -156,7 +156,7 @@ func pingScan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net.H
 			uintptr(unsafe.Pointer(&messageHeaders[0])),
 			uintptr(len(messageHeaders)),
 		)
-		
+
 		if errno != 0 {
 			c.errorChan <- errno
 		}

--- a/scanner/vertical.go
+++ b/scanner/vertical.go
@@ -100,7 +100,7 @@ func pingScan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net.H
 	<-r.ReadyToInterceptChan
 
 	IcmpPacketEthernetPart = prepareIcmpPacketEthernetPart(r.SocketParameters.SourceInterface.HardwareAddr, gatewayMac)
-	IcmpPacketIpPart = prepareIcmpPacketIpPartTemplate(r.Route.Gw)
+	IcmpPacketIpPart = prepareIcmpPacketIpPartTemplate(r.Route.Src)
 
 	for _, ipChunk := range utils.IterateIpRangeChunksBytes(r.Start, r.End) {
 		for i := range ipChunk {

--- a/scanner/vertical.go
+++ b/scanner/vertical.go
@@ -52,7 +52,7 @@ func arpScan(c *scannerContext, r *router.IpRangeRouteContext, arpWg *sync.WaitG
 			}
 
 			ioVectors[i][2] = syscall.Iovec{
-				Base: &constants.ArpPacketPadding[0],
+				Base: &constants.ArpPacketPaddingPart[0],
 				Len:  18,
 			}
 
@@ -89,30 +89,29 @@ func pingScan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net.H
 
 	// Prepare slices of structures for the sendmmsg syscall
 	var messageHeaders [constants.IOVecPacketsChunkSize]Mmsghdr
-	var rawICMPPackets [constants.IOVecPacketsChunkSize][constants.MinFrameSize]byte
-	var ioVectors [constants.IOVecPacketsChunkSize]syscall.Iovec
+	var rawICMPPacketsIpPart [constants.IOVecPacketsChunkSize][constants.ICMPPacketIPPartSize]byte
+	var ioVectors [constants.IOVecPacketsChunkSize][3]syscall.Iovec
+	var IcmpPacketEthernetPart [constants.ICMPPacketEthernetPartSize]byte
+	var IcmpPacketIpPart [constants.ICMPPacketIPPartSize]byte
 
 	pingWg.Add(1)
 	go interceptPingPackets(c, r, pingWg)
 
 	<-r.ReadyToInterceptChan
 
-	pingPacketTemplate := prepareIcmpEchoPacketTemplate(r.SocketParameters.SourceInterface.HardwareAddr,
-		gatewayMac,
-		r.Route.Src)
-
-	packetLength := uint64(constants.MinFrameSize)
+	IcmpPacketEthernetPart = prepareIcmpPacketEthernetPart(r.SocketParameters.SourceInterface.HardwareAddr, gatewayMac)
+	IcmpPacketIpPart = prepareIcmpPacketIpPartTemplate(r.Route.Gw)
 
 	for _, ipChunk := range utils.IterateIpRangeChunksBytes(r.Start, r.End) {
 		for i := range ipChunk {
-			rawICMPPackets[i] = pingPacketTemplate
-			copy(rawICMPPackets[i][30:], ipChunk[i][:])
+			rawICMPPacketsIpPart[i] = IcmpPacketIpPart
+			copy(rawICMPPacketsIpPart[i][16:], ipChunk[i][:])
 
 			var sum uint32
 			// Calculate sum over IP header from byte 14 to 33 (inclusive)
-			for j := constants.IpV4HeaderStart; j < constants.IpHeaderLength+constants.IpV4HeaderStart; j += 2 {
+			for j := 0; j < constants.ICMPPacketIPPartSize; j += 2 {
 				// Sum 16-bit words formed by adjacent bytes
-				sum += uint32(rawICMPPackets[i][j])<<8 | uint32(rawICMPPackets[i][j+1])
+				sum += uint32(rawICMPPacketsIpPart[i][j])<<8 | uint32(rawICMPPacketsIpPart[i][j+1])
 			}
 
 			// Add carries from top 16 bits into lower 16 bits
@@ -120,18 +119,26 @@ func pingScan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net.H
 			sum = (sum & 0xFFFF) + (sum >> 16)
 
 			// Write one's complement of sum into IP checksum field at bytes 24 and 25 in big-endian format
-			binary.BigEndian.PutUint16(rawICMPPackets[i][24:26], ^uint16(sum))
+			binary.BigEndian.PutUint16(rawICMPPacketsIpPart[i][10:12], ^uint16(sum))
 
 			// Proceed with setting up iovec and message headers
-			ioVectors[i] = syscall.Iovec{
-				Base: &rawICMPPackets[i][0],
-				Len:  packetLength,
+			ioVectors[i][0] = syscall.Iovec{
+				Base: &IcmpPacketEthernetPart[0],
+				Len:  constants.ICMPPacketEthernetPartSize,
+			}
+			ioVectors[i][1] = syscall.Iovec{
+				Base: &rawICMPPacketsIpPart[i][0],
+				Len:  constants.ICMPPacketIPPartSize,
+			}
+			ioVectors[i][2] = syscall.Iovec{
+				Base: &constants.ICMPPacketICMPPartAndPadding[0],
+				Len:  constants.ICMPPacketICMPPartAndPaddingSize,
 			}
 			messageHeaders[i].Msg = syscall.Msghdr{
 				Name:    r.SocketParameters.SocketAddressName,
 				Namelen: r.SocketParameters.SocketAddressNameLen,
-				Iov:     &ioVectors[i],
-				Iovlen:  1,
+				Iov:     &ioVectors[i][0],
+				Iovlen:  3,
 			}
 		}
 		if err := Limiter.Wait(context.Background()); err != nil {
@@ -148,7 +155,7 @@ func pingScan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net.H
 			c.errorChan <- errno
 		}
 	}
-	// Pause to give hosts time to respond to ARP requests
+	// Pause to give hosts time to respond to Ping requests
 	time.Sleep(constants.DefaultTimeout)
 	r.DoneChan <- true
 }


### PR DESCRIPTION
Changed the structure of iovec arrays. User time reduced by 15.31% (no need to generate complete packets). Real time increased by 6.29% (due to kernel-level packet assembly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced network packet preparation with more granular control over Ethernet, IP, and ARP/ICMP packet components.
	- Improved packet template generation for network scanning.

- **Improvements**
	- Refined constants and variables for ARP and ICMP packet structures.
	- Updated syscall index comments for better clarity.
	- Optimized packet preparation methods in the network scanner.

- **Technical Updates**
	- Restructured packet template generation functions.
	- Updated byte array sizes and compositions for network packets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->