### PR TITLE
refactor(scanner): introduce Stream API and cleanup unused code

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -122,33 +122,23 @@ func InteractiveScan(rList []rule.Rule) {
 	}
 
 	for _, r := range rList {
-		findingsChan, errChan, err := scanner.Scan(r)
+		stream, err := scanner.Scan(r)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error while initiating scan of network %s: %v\n", r.Network, err)
 			os.Exit(1)
 		}
 
-		for findingsChan != nil || errChan != nil {
-			select {
-			case f, ok := <-findingsChan:
-				if !ok {
-					findingsChan = nil
-					continue
-				}
-
-				switch v := f.(type) {
-				case scanner.Host:
-					printDiscovery(v)
-				case scanner.Port:
-					printPortInfo(v)
-				}
-			case e, ok := <-errChan:
-				if !ok {
-					errChan = nil
-					continue
-				}
-				fmt.Fprintf(os.Stderr, "Error while scanning network %s: %v\n", r.Network, e)
+		for f := range stream.Findings {
+			switch v := f.(type) {
+			case scanner.Host:
+				printDiscovery(v)
+			case scanner.Port:
+				printPortInfo(v)
 			}
+		}
+
+		if err = stream.Wait(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error while scanning network %s: %v\n", r.Network, err)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.9
 	github.com/spf13/pflag v1.0.10
 	github.com/vishvananda/netlink v1.3.1
+	golang.org/x/sync v0.17.0
 	golang.org/x/time v0.14.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
 golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -14,16 +14,6 @@ import (
 	"time"
 )
 
-// Rule defines a scanning rule. The user can specify only Network, Ports, portsScanTechniques, and options.
-type Rule struct {
-	FQDN               string
-	Network            net.IPNet
-	Ports              []uint16
-	PortsRanges        []PortsRange
-	PortScanTechniques PortsScanTechniques
-	Options            Options
-}
-
 func (pr PortsRange) Expand() []uint16 {
 	var ports []uint16
 	ports = make([]uint16, 0)

--- a/rule/structs.go
+++ b/rule/structs.go
@@ -16,6 +16,16 @@ type Options struct {
 	NoIpV6Multicast bool
 }
 
+// Rule defines a scanning rule. The user can specify only Network, Ports, portsScanTechniques, and options.
+type Rule struct {
+	FQDN               string
+	Network            net.IPNet
+	Ports              []uint16
+	PortsRanges        []PortsRange
+	PortScanTechniques PortsScanTechniques
+	Options            Options
+}
+
 type PortsScanTechniques struct {
 	Syn bool
 	Udp bool

--- a/scanner/common.go
+++ b/scanner/common.go
@@ -15,11 +15,14 @@ import (
 	"sync"
 	"syscall"
 
+	"context"
+
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/gopacket/gopacket/pcap"
 	psnet "github.com/shirou/gopsutil/v4/net"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 )
 
@@ -133,102 +136,133 @@ func SetPps(pps int) error {
 	return nil
 }
 
-// Scan is the main entry point for scanning using the provided rule.
-func Scan(scanRule rule.Rule) (<-chan ScanFinding, <-chan error, error) {
-	var ipRangeScannerWg sync.WaitGroup
-
+// Scan is the main public entry point for scanning using the provided rule.
+// Internally, it launches multiple IPv4/IPv6 scanning goroutines, collects
+// their results, and merges all findings and errors into a single Stream.
+func Scan(scanRule rule.Rule) (*Stream, error) {
 	if limiter == nil {
-		err := SetPps(constants.DefaultPpsLimit)
-		if err != nil {
-			return nil, nil, err
+		if err := SetPps(constants.DefaultPpsLimit); err != nil {
+			return nil, err
 		}
 	}
 
 	scanCtx, err := createScannerContext(scanRule)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	// If the network is loopback, handle separately
+	// Loopback networks are handled separately
 	if scanRule.Network.IP.IsLoopback() {
-		return getLocalPorts(scanRule)
+		findingsChan, errChan, err := getLocalPorts(scanRule)
+		if err != nil {
+			return nil, err
+		}
+		return wrapChannels(findingsChan, errChan), nil
 	}
 
+	var ipRangeScannerWg sync.WaitGroup
+
+	// IPv6 scan
 	if scanRule.Network.IP.To4() == nil && scanRule.Network.IP.To16() != nil {
-		// start ipv6 scan
 		if scanRule.Options.NoHostDiscovery {
 			for _, networkRange := range scanCtx.IpRanges {
 				switch {
 				case networkRange.Route.Gw != nil:
-					ipRangeScannerWg.Go(func() {
-						scanV6WithoutHostDiscovery(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV6WithoutHostDiscovery(scanCtx, networkRange) })
 				case scanCtx.defaultGateway != nil:
 					networkRange.Route.Gw = scanCtx.defaultGateway
-
-					ipRangeScannerWg.Go(func() {
-						scanV6WithoutHostDiscovery(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV6WithoutHostDiscovery(scanCtx, networkRange) })
 				default:
-					return nil, nil, fmt.Errorf("unable to determine a route to network range %s-%s. Gateway required to scan with \"no-host-discovery\" option enabled", networkRange.Start, networkRange.End)
+					return nil, fmt.Errorf("unable to determine a route to network range %s-%s (gateway required for no-host-discovery)", networkRange.Start, networkRange.End)
 				}
 			}
 		} else {
 			for _, networkRange := range scanCtx.IpRanges {
 				switch {
 				case networkRange.Route.Gw == nil && scanRule.Options.NoIpV6Multicast && scanCtx.defaultGateway == nil:
-					return nil, nil, fmt.Errorf("unable to build a route to the range: the specified IPv6 range %s-%s has no gateway, no default gateway, and multicast is disabled, so the destination MAC address cannot be determined", networkRange.Start, networkRange.End)
+					return nil, fmt.Errorf("no route to IPv6 range %s-%s (no gateway and multicast disabled)", networkRange.Start, networkRange.End)
 				case scanRule.Options.NoIpV6Multicast:
 					if networkRange.Route.Gw == nil {
 						networkRange.Route.Gw = scanCtx.defaultGateway
 					}
-					ipRangeScannerWg.Go(func() {
-						scanV6OverGateway(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV6OverGateway(scanCtx, networkRange) })
 				case networkRange.Route.Gw == nil:
-					ipRangeScannerWg.Go(func() {
-						scanV6PointToPoint(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV6PointToPoint(scanCtx, networkRange) })
 				default:
-					ipRangeScannerWg.Go(func() {
-						scanV6OverGateway(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV6OverGateway(scanCtx, networkRange) })
 				}
 			}
 		}
 	} else {
-		// start ipv4 scan
+		// IPv4 scan
 		if scanRule.Options.NoHostDiscovery {
 			for _, networkRange := range scanCtx.IpRanges {
 				switch {
 				case networkRange.Route.Gw != nil:
-					ipRangeScannerWg.Go(func() {
-						scanV4WithoutHostDiscovery(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV4WithoutHostDiscovery(scanCtx, networkRange) })
 				case scanCtx.defaultGateway != nil:
 					networkRange.Route.Gw = scanCtx.defaultGateway
-					ipRangeScannerWg.Go(func() {
-						scanV4WithoutHostDiscovery(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV4WithoutHostDiscovery(scanCtx, networkRange) })
 				default:
-					return nil, nil, fmt.Errorf("unable to determine a route to network range %s-%s. Gateway required to scan with \"no-host-discovery\" option enabled", networkRange.Start, networkRange.End)
+					return nil, fmt.Errorf("unable to determine a route to network range %s-%s (gateway required for no-host-discovery)", networkRange.Start, networkRange.End)
 				}
 			}
 		} else {
 			for _, networkRange := range scanCtx.IpRanges {
 				if networkRange.Route.Gw == nil {
-					ipRangeScannerWg.Go(func() {
-						scanV4PointToPoint(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV4PointToPoint(scanCtx, networkRange) })
 				} else {
-					ipRangeScannerWg.Go(func() {
-						scanV4OverGateway(scanCtx, networkRange)
-					})
+					ipRangeScannerWg.Go(func() { scanV4OverGateway(scanCtx, networkRange) })
 				}
 			}
 		}
 	}
-	return scanCtx.findingsChan, scanCtx.errorChan, nil
+
+	// Wait for all scan goroutines to finish, then close channels.
+	go func() {
+		ipRangeScannerWg.Wait()
+		close(scanCtx.findingsChan)
+		close(scanCtx.errorChan)
+	}()
+
+	// Wrap internal channels into a unified Stream
+	return wrapChannels(scanCtx.findingsChan, scanCtx.errorChan), nil
+}
+
+// wrapChannels merges internal findings and error channels into a single Stream.
+// It launches two goroutines: one to forward scan findings, another to collect errors.
+// The Wait() method of Stream waits until both finish and returns the first error (if any).
+func wrapChannels(findings <-chan ScanFinding, errs <-chan error) *Stream {
+	out := make(chan ScanFinding, 256)
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Forward all findings to a single output channel
+	g.Go(func() error {
+		defer close(out)
+		for f := range findings {
+			select {
+			case out <- f:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+
+	// Collect and return the first error
+	g.Go(func() error {
+		for e := range errs {
+			if e != nil {
+				return e
+			}
+		}
+		return nil
+	})
+
+	return &Stream{
+		Findings: out,
+		Wait:     g.Wait,
+	}
 }
 
 // createScannerContext initializes scannerContext from the provided rule.

--- a/scanner/structs.go
+++ b/scanner/structs.go
@@ -17,6 +17,15 @@ type mmsghdr struct {
 	_   [4]byte
 }
 
+// Stream represents a unified output stream for scan results.
+// It hides internal channels and provides a simple interface:
+//   - Findings: a single channel for all discoveries (hosts, ports, etc.)
+//   - Wait(): blocks until all scanning goroutines finish, and returns the first error (if any)
+type Stream struct {
+	Findings <-chan ScanFinding
+	Wait     func() error
+}
+
 // scannerContext holds overall state for scanning, including error channels,
 // routes, and a raw socket descriptor.
 type scannerContext struct {

--- a/scanner/v4.go
+++ b/scanner/v4.go
@@ -19,12 +19,6 @@ import (
 	"github.com/gopacket/gopacket/pcap"
 )
 
-// getLocalhostV4Ports is a stub for handling local ports on a loopback interface.
-func getLocalhostV4Ports(c *scannerContext) {
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
-}
-
 // interceptTransportV4Responses captures packets for TCP/UDP discovery when network is IPv4.
 // For TCP, it listens for SYN+ACK; for UDP, it captures all packets.
 func interceptTransportV4Responses(c *scannerContext, r *router.IpRangeRouteContext, bpf *pcap.BPF) {
@@ -1376,8 +1370,6 @@ func scanPortsV4OverGateway(c *scannerContext, r *router.IpRangeRouteContext, po
 
 // scanV4WithoutHostDiscovery This function is used when the user doesn’t want to check if the host responds to ping requests to verify that it is online. Instead, we immediately start scanning ports, using the gateway’s MAC address as the destination for Layer 2.
 func scanV4WithoutHostDiscovery(c *scannerContext, r *router.IpRangeRouteContext) {
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
 
 	var (
 		gatewayMacAddress net.HardwareAddr
@@ -1930,9 +1922,6 @@ func pingV4Scan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net
 // scanV4OverGateway scanning through a gateway if network is not local.
 func scanV4OverGateway(c *scannerContext, r *router.IpRangeRouteContext) {
 
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
-
 	var pingWg sync.WaitGroup
 	var gatewayMacAddress net.HardwareAddr
 	var err error
@@ -1969,9 +1958,7 @@ func scanV4OverGateway(c *scannerContext, r *router.IpRangeRouteContext) {
 
 // scanV4PointToPoint performs direct scanning in a single subnet without a gateway.
 func scanV4PointToPoint(c *scannerContext, r *router.IpRangeRouteContext) {
-	//defer fmt.Println("DEBUG: scanPointToPoint is done")
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
+
 	var p2pWg sync.WaitGroup
 
 	// Start ARP-based host discovery

--- a/scanner/v6.go
+++ b/scanner/v6.go
@@ -28,12 +28,6 @@ func solicitedNode(ip net.IP) (net.IP, net.HardwareAddr) {
 	return mIP, mMAC
 }
 
-// getLocalhostV6Ports is a stub for handling local ports on a loopback interface.
-func getLocalhostV6Ports(c *scannerContext) {
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
-}
-
 // interceptTransportV6Responses captures packets for TCP/UDP discovery when network is IPv6.
 // For TCP, it listens for SYN+ACK; for UDP, it captures all packets.
 func interceptTransportV6Responses(c *scannerContext, r *router.IpRangeRouteContext, bpf *pcap.BPF) {
@@ -407,8 +401,6 @@ func prepareIpv6PartTemplate(sourceIP net.IP, length uint16, transportLayer byte
 // original IPv4 routine; only those parts that MUST differ for IPv6 were
 // changed.
 func scanV6WithoutHostDiscovery(c *scannerContext, r *router.IpRangeRouteContext) {
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
 
 	var (
 		// Gateway MAC address.
@@ -776,9 +768,6 @@ func scanV6WithoutHostDiscovery(c *scannerContext, r *router.IpRangeRouteContext
 // scanV6OverGateway scanning through a gateway if network is not local.
 func scanV6OverGateway(c *scannerContext, r *router.IpRangeRouteContext) {
 
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
-
 	var pingWg sync.WaitGroup
 	var gatewayMacAddress net.HardwareAddr
 	var err error
@@ -938,8 +927,6 @@ func pingV6Scan(c *scannerContext, r *router.IpRangeRouteContext, gatewayMac net
 
 // scanV6PointToPoint performs direct scanning in a single subnet without a gateway.
 func scanV6PointToPoint(c *scannerContext, r *router.IpRangeRouteContext) {
-	defer close(c.errorChan)
-	defer close(c.findingsChan)
 
 	var p2pWg sync.WaitGroup
 


### PR DESCRIPTION
- Added new Stream struct that simplifies channel handling and improves public API usability
- Added wrapChannels() helper to forward internal findings/error channels into Stream
- Removed unused functions getLocalhostV6Ports and getLocalhostV4Ports
- Moved rule struct definition into structs.go for better organization