### PR TITLE
Fix formatting for help message in common.go

### DIFF
--- a/constants/common.go
+++ b/constants/common.go
@@ -251,4 +251,5 @@ Flags:
   --pps <value>           Global packets per second cap (all rules combined)
   --threads <N>           Max number of worker goroutines (default: runtime.GOMAXPROCS(0))
   --version               Print version and exit
-  -h, --help             Show this help message and exit`
+  -h, --help             Show this help message and exit
+`


### PR DESCRIPTION
Ensure help output ends with a newline, so the shell prompt appears on the next line
<img width="1085" height="148" alt="SCR-20251126-mrqm" src="https://github.com/user-attachments/assets/39567e4c-56da-4905-8bdd-393e90ce0166" />
